### PR TITLE
Fixing typo in MPICC name

### DIFF
--- a/telephone/Makefile
+++ b/telephone/Makefile
@@ -1,4 +1,4 @@
-MPICC=mpiicc
+MPICC=mpicc
 
 .PHONY: all clean
 


### PR DESCRIPTION
Wasn't able to make on the boxes due to typo as mpiicc, this should hopefully fix it